### PR TITLE
Add runall.py input path to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ environment.
 1. Change to directory for second stage of reidentification
     - `cd ${workdir}/recon_replication/reidpaper_python/python/`
 1. Run second stage of reidentification
-    - `setsid python3 runall.py`
+    - `setsid python3 runall.py ${workdir}/data/reid_module`
 1. Change to the results directory
     - `cd ${workdir}/recon_replication/reidpaper_python/results/`
 1. Numerical result from this module are not publicly shareable and will be located in:


### PR DESCRIPTION
The reidpaper instructions should specify the input path for runall.py.

Without this, it will use a default root-based path of `/data/reid_module`, instead of `${workdir}/data/reid_module`.